### PR TITLE
Pass participantID and sessionID when running digit span tasks

### DIFF
--- a/lib/src/digit_span_tasks/config/config_dsb.dart
+++ b/lib/src/digit_span_tasks/config/config_dsb.dart
@@ -1,11 +1,10 @@
-import 'package:digit_span_tasks/digit_span_tasks.dart';
-
-UserConfig configDSB = UserConfig(
-  stimListPractice: [
+class DSBConfig {
+  List<String> practiceStim = <String>[
     '36',
     '283',
-  ],
-  stimListExperimental: [
+  ];
+
+  List<String> experimentalStim = <String>[
     '26',
     '49',
     '926',
@@ -18,5 +17,5 @@ UserConfig configDSB = UserConfig(
     '917468',
     '3692478',
     '3751682',
-  ],
-);
+  ];
+}

--- a/lib/src/digit_span_tasks/config/config_dsf.dart
+++ b/lib/src/digit_span_tasks/config/config_dsf.dart
@@ -1,11 +1,10 @@
-import 'package:digit_span_tasks/digit_span_tasks.dart';
-
-UserConfig configDSF = UserConfig(
-  stimListPractice: [
+class DSFConfig {
+  List<String> practiceStim = <String>[
     '27',
     '689',
-  ],
-  stimListExperimental: [
+  ];
+
+  List<String> experimentalStim = <String>[
     '83',
     '67',
     '254',
@@ -22,5 +21,5 @@ UserConfig configDSF = UserConfig(
     '71584926',
     '472638951',
     '521697483',
-  ],
-);
+  ];
+}

--- a/lib/src/digit_span_tasks/task_runners/run_dsb.dart
+++ b/lib/src/digit_span_tasks/task_runners/run_dsb.dart
@@ -6,8 +6,16 @@ Future<DigitSpanTasksData> runDigitSpanBackwards({
   required String participantID,
   required String sessionID,
 }) async {
+  final DSBConfig dsbConfig = DSBConfig();
+  final UserConfig userConfig = UserConfig(
+    stimListPractice: dsbConfig.practiceStim,
+    stimListExperimental: dsbConfig.experimentalStim,
+    participantID: participantID,
+    sessionID: sessionID,
+  );
+
   DigitSpanTasksData data = await Get.to(() => DigitSpanBackwards(
-        config: configDSB,
+        config: userConfig,
       ));
 
   return data;

--- a/lib/src/digit_span_tasks/task_runners/run_dsb.dart
+++ b/lib/src/digit_span_tasks/task_runners/run_dsb.dart
@@ -2,7 +2,10 @@ import 'package:digit_span_tasks/digit_span_tasks.dart';
 import 'package:get/get.dart';
 import '../config/config_dsb.dart';
 
-Future<DigitSpanTasksData> runDigitSpanBackwards() async {
+Future<DigitSpanTasksData> runDigitSpanBackwards({
+  required String participantID,
+  required String sessionID,
+}) async {
   DigitSpanTasksData data = await Get.to(() => DigitSpanBackwards(
         config: configDSB,
       ));

--- a/lib/src/digit_span_tasks/task_runners/run_dsb.dart
+++ b/lib/src/digit_span_tasks/task_runners/run_dsb.dart
@@ -2,6 +2,7 @@ import 'package:digit_span_tasks/digit_span_tasks.dart';
 import 'package:get/get.dart';
 import '../config/config_dsb.dart';
 
+/// Configure and start the DSB
 Future<DigitSpanTaskData> runDigitSpanBackwards({
   required String participantID,
   required String sessionID,

--- a/lib/src/digit_span_tasks/task_runners/run_dsb.dart
+++ b/lib/src/digit_span_tasks/task_runners/run_dsb.dart
@@ -2,7 +2,7 @@ import 'package:digit_span_tasks/digit_span_tasks.dart';
 import 'package:get/get.dart';
 import '../config/config_dsb.dart';
 
-Future<DigitSpanTasksData> runDigitSpanBackwards({
+Future<DigitSpanTaskData> runDigitSpanBackwards({
   required String participantID,
   required String sessionID,
 }) async {
@@ -14,7 +14,7 @@ Future<DigitSpanTasksData> runDigitSpanBackwards({
     sessionID: sessionID,
   );
 
-  DigitSpanTasksData data = await Get.to(() => DigitSpanBackwards(
+  DigitSpanTaskData data = await Get.to(() => DigitSpanBackwards(
         config: userConfig,
       ));
 

--- a/lib/src/digit_span_tasks/task_runners/run_dsf.dart
+++ b/lib/src/digit_span_tasks/task_runners/run_dsf.dart
@@ -6,8 +6,15 @@ Future<DigitSpanTasksData> runDigitSpanForward({
   required String participantID,
   required String sessionID,
 }) async {
+  final DSFConfig dsfConfig = DSFConfig();
+  final UserConfig userConfig = UserConfig(
+      stimListPractice: dsfConfig.practiceStim,
+      stimListExperimental: dsfConfig.experimentalStim,
+      participantID: participantID,
+      sessionID: sessionID);
+
   DigitSpanTasksData data = await Get.to(() => DigitSpanForward(
-        config: configDSF,
+        config: userConfig,
       ));
 
   return data;

--- a/lib/src/digit_span_tasks/task_runners/run_dsf.dart
+++ b/lib/src/digit_span_tasks/task_runners/run_dsf.dart
@@ -2,6 +2,7 @@ import 'package:digit_span_tasks/digit_span_tasks.dart';
 import 'package:get/get.dart';
 import '../config/config_dsf.dart';
 
+/// Configure and start the DSF
 Future<DigitSpanTaskData> runDigitSpanForward({
   required String participantID,
   required String sessionID,

--- a/lib/src/digit_span_tasks/task_runners/run_dsf.dart
+++ b/lib/src/digit_span_tasks/task_runners/run_dsf.dart
@@ -2,7 +2,7 @@ import 'package:digit_span_tasks/digit_span_tasks.dart';
 import 'package:get/get.dart';
 import '../config/config_dsf.dart';
 
-Future<DigitSpanTasksData> runDigitSpanForward({
+Future<DigitSpanTaskData> runDigitSpanForward({
   required String participantID,
   required String sessionID,
 }) async {
@@ -13,7 +13,7 @@ Future<DigitSpanTasksData> runDigitSpanForward({
       participantID: participantID,
       sessionID: sessionID);
 
-  DigitSpanTasksData data = await Get.to(() => DigitSpanForward(
+  DigitSpanTaskData data = await Get.to(() => DigitSpanForward(
         config: userConfig,
       ));
 

--- a/lib/src/digit_span_tasks/task_runners/run_dsf.dart
+++ b/lib/src/digit_span_tasks/task_runners/run_dsf.dart
@@ -2,7 +2,10 @@ import 'package:digit_span_tasks/digit_span_tasks.dart';
 import 'package:get/get.dart';
 import '../config/config_dsf.dart';
 
-Future<DigitSpanTasksData> runDigitSpanForward() async {
+Future<DigitSpanTasksData> runDigitSpanForward({
+  required String participantID,
+  required String sessionID,
+}) async {
   DigitSpanTasksData data = await Get.to(() => DigitSpanForward(
         config: configDSF,
       ));

--- a/lib/src/services/run_session.dart
+++ b/lib/src/services/run_session.dart
@@ -1,5 +1,6 @@
 import 'package:cognitive_data/trial_type.dart';
 import 'package:digit_span_tasks/digit_span_tasks.dart';
+import 'package:flutter/material.dart';
 import 'package:mdigit_span_tasks/src/data_manager/data_manager.dart';
 import 'package:mdigit_span_tasks/src/data_manager/session_id_creator.dart';
 import 'package:mdigit_span_tasks/src/services/data_processor.dart';
@@ -16,7 +17,7 @@ void runSession({required Function taskRunner, required String dbName}) async {
   /// session id for both practice and experimental data.
   final String sessionID = createSessionID(
     participantID: participantID,
-    startTime: data.practiceData.sessionData.startTime.toString(),
+    startTime: TimeOfDay.now().toString(),
   );
 
   DigitSpanTasksData data = await taskRunner();

--- a/lib/src/services/run_session.dart
+++ b/lib/src/services/run_session.dart
@@ -26,7 +26,10 @@ void runSession(
     startTime: TimeOfDay.now().toString(),
   );
 
-  DigitSpanTasksData data = await taskRunner();
+  DigitSpanTasksData data = await taskRunner(
+    participantID: participantID,
+    sessionID: sessionID,
+  );
 
   /// TODO Specify type
   final dataPractice = data.practiceData;

--- a/lib/src/services/run_session.dart
+++ b/lib/src/services/run_session.dart
@@ -11,7 +11,6 @@ import '../participant_info/participant_info_dialog.dart';
 /// cognitive task specificed with [taskRunner].
 void runSession({required Function taskRunner, required String dbName}) async {
   final String participantID = await showParticipantInfoDialog();
-  DigitSpanTasksData data = await taskRunner();
 
   /// We use the startTime for the practice session to create a single
   /// session id for both practice and experimental data.
@@ -19,6 +18,8 @@ void runSession({required Function taskRunner, required String dbName}) async {
     participantID: participantID,
     startTime: data.practiceData.sessionData.startTime.toString(),
   );
+
+  DigitSpanTasksData data = await taskRunner();
 
   /// TODO Specify type
   final dataPractice = data.practiceData;

--- a/lib/src/services/run_session.dart
+++ b/lib/src/services/run_session.dart
@@ -26,7 +26,7 @@ void runSession(
     startTime: TimeOfDay.now().toString(),
   );
 
-  DigitSpanTasksData data = await taskRunner(
+  DigitSpanTaskData data = await taskRunner(
     participantID: participantID,
     sessionID: sessionID,
   );

--- a/lib/src/services/run_session.dart
+++ b/lib/src/services/run_session.dart
@@ -10,7 +10,13 @@ import '../participant_info/participant_info_dialog.dart';
 /// Run a data collection session
 /// Running a session includes configuring everything needed and running a
 /// cognitive task specificed with [taskRunner].
-void runSession({required Function taskRunner, required String dbName}) async {
+void runSession(
+    {required Function({
+      required String participantID,
+      required String sessionID,
+    })
+        taskRunner,
+    required String dbName}) async {
   final String participantID = await showParticipantInfoDialog();
 
   /// We use the startTime for the practice session to create a single


### PR DESCRIPTION
## Description

The participantID and sessionID are now required when running the DigitSpanForward and DigitSpanBackward.

These changes define these properties before running the digit spant tasks and pass them as parameters.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
