### PR TITLE
Improve sessionID created by createSessionID()

### DIFF
--- a/lib/src/data_manager/session_id_creator.dart
+++ b/lib/src/data_manager/session_id_creator.dart
@@ -1,6 +1,6 @@
-String createSessionID(
-    {required String participantID, required String startTime}) {
-  final String sessionID = participantID + startTime;
+String createSessionID({required String participantID}) {
+  final DateTime startTime = DateTime.now();
+  final String sessionID = participantID + startTime.toString();
 
   return sessionID;
 }

--- a/lib/src/data_manager/session_id_creator.dart
+++ b/lib/src/data_manager/session_id_creator.dart
@@ -1,6 +1,6 @@
 String createSessionID({required String participantID}) {
   final DateTime startTime = DateTime.now();
-  final String sessionID = participantID + startTime.toString();
+  final String sessionID = "${participantID}_${startTime.toString()}";
 
   return sessionID;
 }

--- a/lib/src/data_manager/session_id_creator.dart
+++ b/lib/src/data_manager/session_id_creator.dart
@@ -1,3 +1,5 @@
+/// Create a unique [String] identifier by concatenating the [participantID]
+/// with the current time.
 String createSessionID({required String participantID}) {
   final DateTime startTime = DateTime.now();
   final String sessionID = "${participantID}_${startTime.toString()}";

--- a/lib/src/services/run_session.dart
+++ b/lib/src/services/run_session.dart
@@ -21,7 +21,6 @@ void runSession(
   /// session id for both practice and experimental data.
   final String sessionID = createSessionID(
     participantID: participantID,
-    startTime: TimeOfDay.now().toString(),
   );
 
   DigitSpanTaskData data = await taskRunner(


### PR DESCRIPTION
## Description

Creating a session id using createSessionID() was improved by
- fixing an error by now converting the DateTime.now() object to string before concatenating it to the participant id
- defining the startTime inside the createSessionID(). Doesn't require the caller to pass data that is easy to get by the function and that won't change
- using the format [participantID]_[startTime] to make the session id more readable.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
